### PR TITLE
chore: update PHPUnit and Laravel versions to support Laravel 13

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,9 +14,11 @@ jobs:
           matrix:
               os: [ubuntu-latest]
               php: [ 8.4, 8.3, 8.2 ]
-              laravel: [ '10.*', '11.*', '12.*' ]
+              laravel: [ '10.*', '11.*', '12.*', '13.*' ]
               stability: [prefer-lowest, prefer-stable]
               include:
+                  - laravel: 13.*
+                    testbench: 11.*
                   - laravel: 12.*
                     testbench: 10.*
                   - laravel: 11.*

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     "require": {
         "php": "^8.2",
         "guzzlehttp/guzzle": "^7.1",
-        "illuminate/notifications": "^10.0 || ^11.0 || ^12.0",
-        "illuminate/support": "^10.0 || ^11.0 || ^12.0"
+        "illuminate/notifications": "^10.0 || ^11.0 || ^12.0 || ^13.0",
+        "illuminate/support": "^10.0 || ^11.0 || ^12.0 || ^13.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.5",
-        "phpunit/phpunit": "^10.5|^11.0|^12.0"
+        "phpunit/phpunit": "^10.5|^11.0|^12.0|^13.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR adds support for Laravel 13. The changes make sure the package can be used with the current version of Laravel. 
Furthermore the CI-Test Matrix now also includes Laravel 13